### PR TITLE
MPI_Init_thread mit ptscotch

### DIFF
--- a/DolfinFisherSolver/cmake_init.sh
+++ b/DolfinFisherSolver/cmake_init.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# source $HOME/usr/source_env.sh first before running this
+
+rm -rf build
+mkdir -p build
+cd build && \
+    cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpic++ -DCMAKE_BUILD_TYPE=RelWithDebInfo ..

--- a/DolfinFisherSolver/main.cpp
+++ b/DolfinFisherSolver/main.cpp
@@ -49,10 +49,11 @@ std::vector<std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>> 
 
 
 int main(int argc, char* argv[]){
-
-	// initialize MPI
-	MPI_Init(NULL, NULL);
-	int rank, nprocs;
+    // initialize MPI
+    // MPI_Init(NULL, NULL);
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    int rank, nprocs;
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	MPI_Comm_size(MPI_COMM_WORLD,&nprocs);
 


### PR DESCRIPTION
Diese Modifikation ist notwendig in dem main.cpp file.  Du solltests das cmake_init.sh script verwenden um einen neuen build folder zu generieren mit den korrekten compile time settings.